### PR TITLE
Add ops: noop, array, concat; change identity signature

### DIFF
--- a/builtin.aqua
+++ b/builtin.aqua
@@ -66,6 +66,10 @@ service Op("op"):
     string_from_b58(b: string) -> string
     bytes_to_b58(bs: []u8) -> string
     bytes_from_b58(b: string) -> []u8
+    -- Applies SHA256 to the given string
+    -- Argument: s - string to apply sha256 to
+    -- Returns: returns sha256 multihash encoded as base58
+    sha256_string(s: stribg) -> string
 
 service Peer("peer"):
     -- Checks if there is a direct connection to the peer identified by a given PeerId
@@ -97,6 +101,14 @@ service Kademlia("kad"):
     -- Instructs node to return the locally-known nodes
     -- in the Kademlia neighborhood for a given key
     neighborhood(key: PeerId, already_hashed: bool) -> []PeerId
+    -- Merges given lists and sorts them by distance to target
+    -- Arguments:
+    -- target – base58 string; result is sorted by XOR distance to target
+    -- left – list of base58 strings
+    -- right – list of base58 strings
+    -- count – how many items to return
+    -- Returns: list of base58 strings sorted by distance to target; list will contain at most count elements
+    merge(target: string, left: []string, right: []string, count: u32) -> []string
 
 service Srv("srv"):
     -- Used to create a service on a certain node
@@ -119,6 +131,10 @@ service Srv("srv"):
     -- alias - settable service name
     -- service_id – ID of the service whose interface you want to name.
     add_alias(alias: string, service_id: string)
+
+    -- Resolves given alias to a service id
+    -- If there's no such alias, throws an error
+    resolve_alias(alias: string) -> string
 
     -- Retrieves the functional interface of a service running
     -- on the node specified in the service call

--- a/builtin.aqua
+++ b/builtin.aqua
@@ -66,7 +66,7 @@ service Op("op"):
     -- takes any number of arguments and wraps them into a single array
     array(a: string, b: string, c: string) -> []string
     -- takes any number of arrays and flattens them by concatenating
-    concat(a: [][]string) -> []string
+    concat(a: []string, b: []string, c: []string) -> []string
     -- takes a single argument and returns it back
     identity(s: ?string) -> ?string
     string_to_b58(s: string) -> string

--- a/builtin.aqua
+++ b/builtin.aqua
@@ -69,7 +69,7 @@ service Op("op"):
     -- Applies SHA256 to the given string
     -- Argument: s - string to apply sha256 to
     -- Returns: returns sha256 multihash encoded as base58
-    sha256_string(s: stribg) -> string
+    sha256_string(s: string) -> string
 
 service Peer("peer"):
     -- Checks if there is a direct connection to the peer identified by a given PeerId

--- a/builtin.aqua
+++ b/builtin.aqua
@@ -61,7 +61,14 @@ data Contact:
     addresses: []string
 
 service Op("op"):
-    identity()
+    -- does nothing
+    noop()
+    -- takes any number of arguments and wraps them into a single array
+    array(a: string, b: string, c: string) -> []string
+    -- takes any number of arrays and flattens them by concatenating
+    concat(a: [][]string) -> []string
+    -- takes a single argument and returns it back
+    identity(s: ?string) -> ?string
     string_to_b58(s: string) -> string
     string_from_b58(b: string) -> string
     bytes_to_b58(bs: []u8) -> string

--- a/builtin.aqua
+++ b/builtin.aqua
@@ -134,6 +134,7 @@ service Srv("srv"):
 
     -- Resolves given alias to a service id
     -- If there's no such alias, throws an error
+    -- Returns: service id associated with the given alias
     resolve_alias(alias: string) -> string
 
     -- Retrieves the functional interface of a service running


### PR DESCRIPTION
I've expressed everything in strings for now. Maybe it makes sense to go golang-style?
like
```go
identity_s(s: ?string) -> ?string
identity_u8(u: ?u8) -> ?u8
identity_u32(u: ?u32) -> ?u32

array_2(a: string, b: string, c: string) -> []string
array_3(a: string, b: string, c: string) -> []string
array_4(a: string, b: string, c: string, d: string) -> []string
array_5(a: string, b: string, c: string, d: string, e: string) -> []string

concat_2(a: []string, b: []string) -> []string
concat_3(a: []string, b: []string, c: []string) -> []string
```

and so on
