### PR TITLE
Peer.timeout: make message non-optional

### DIFF
--- a/builtin.aqua
+++ b/builtin.aqua
@@ -130,9 +130,9 @@ service Peer("peer"):
     -- Get Unix timestamp in seconds
     timestamp_sec() -> u64
 
-    -- Blocks for the given number of milliseconds. Meant to be used inside `par` blocks.
-    -- If `message` is passed, it's returned after duration has passed
-    timeout(duration_ms: u64, message: ?string) -> ?string
+    -- Blocks for the given number of milliseconds. Meant to be used within `par` blocks.
+    -- message is returned after duration has passed
+    timeout(duration_ms: u64, message: string) -> string
 
 service Kademlia("kad"):
     -- Instructs node to return the locally-known nodes


### PR DESCRIPTION
This is a more aqua-friendly API atm. Lifting literal string to `?string` is very verbose in current Aqua, so optional `message` leads to a lot of boilerplate code:
```
msg: *string
msg <<- "timeout"
status: *?string
success: *string
success <<- "success"
status <<- success
par status <- Peer.timeout(rtt, msg)
if status! == success:
    ...
```

Making message non-optional will simplify call-site a lot:
```
status: *string
status <<- "success"
par status <- Peer.timeout(rtt, "timeout")
if status! == "success":
  ...
```