### PR TITLE
BREAKING CHANGE: Fix get_contact, clarify connect and is_connected docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,11 +21,11 @@ jobs:
             key: ${{ runner.os }}-v1-node-${{ hashFiles('**/package-lock.json') }}
             restore-keys: |
                 ${{ runner.os }}-v1-node
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-            node-version: 14
+            node-version: 16
 
       - name: Install aqua compiler
         run: npm install -g @fluencelabs/aqua

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
             key: ${{ runner.os }}-v1-node-${{ hashFiles('**/package-lock.json') }}
             restore-keys: |
                 ${{ runner.os }}-v1-node
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-            node-version: 14
+            node-version: 16
 
       - name: Install aqua compiler
         run: npm install -g @fluencelabs/aqua
@@ -41,7 +41,7 @@ jobs:
       ### Publish to NPM registry
       - uses: actions/setup-node@v1
         with:
-          node-version: "14"
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to NPM

--- a/builtin.aqua
+++ b/builtin.aqua
@@ -107,22 +107,6 @@ service Op("op"):
     concat_strings(a: string, b: string) -> string
 
 service Peer("peer"):
-    -- Checks if there is a direct connection to the peer identified by a given PeerId
-    -- Argument: PeerId – id of the peer to check if there's a connection with
-    -- Returns: bool - true if connected to the peer, false otherwise
-    is_connected(peer: PeerId) -> bool
-
-    -- Initiates a connection to the specified peer
-    -- Arguments:
-    --  id - id of the target peer
-    --  multiaddrs – an array of target peer's addresses
-    -- Returns: bool - true if connection was successful
-    connect(id: PeerId, multiaddrs: ?[]string) -> bool
-    -- Resolves the contact of a peer via Kademlia
-    -- Argument: PeerId – id of the target peer
-    -- Returns: Contact - true if connection was successful
-    get_contact(peer: PeerId) -> Contact
-
     -- Get information about the peer
     identify() -> Info
 
@@ -135,6 +119,34 @@ service Peer("peer"):
     -- Blocks for the given number of milliseconds. Meant to be used within `par` blocks.
     -- message is returned after duration has passed
     timeout(duration_ms: u64, message: string) -> string
+
+    ---- Low level functions for accessing connection pool
+
+    -- Checks if there is a direct connection to the peer identified by a given PeerId
+    -- Argument: PeerId – id of the peer to check if there's a connection with
+    -- Returns: bool - true if connected to the peer, false otherwise
+    -- NOTE:
+    --  This is a very low-level function, it most likely won't fit your goals.
+    --  It's almost always better to use race pattern to check connectivity.
+    --  See https://doc.fluence.dev/aqua-book/language/flow/parallel#timeout-and-race-patterns
+    is_connected(peer: PeerId) -> bool
+
+    -- Initiates a connection to the specified peer
+    -- Arguments:
+    --  id - id of the target peer
+    --  multiaddrs – an array of target peer's addresses
+    -- Returns: bool - true if connection was successful
+    -- NOTE:
+    --  This is a low-level function, it most likely won't fit your goals.
+    --  Most often you just need to use `on id:` and connection will be established automatically.
+    connect(id: PeerId, multiaddrs: []string) -> bool
+
+    -- Returns known multiaddresses of a peer
+    -- Argument: PeerId – id of the target peer
+    -- Returns:
+    --  Contact - if target peer is connected to current peer,
+    --  return data structure with multiaddresses inside, and nil otherwise.
+    get_contact(peer: PeerId) -> ?Contact
 
 service Kademlia("kad"):
     -- Instructs node to return the locally-known nodes


### PR DESCRIPTION
- get_contact now returns `?Contact` to correspond actual impl on Rust Peer
- `multiaddresses` in `connect` are now non-optional, cuz it made absolutely no sense
- move `get_contact`, `connect` and `is_connected` to the bottom of `service Peer` to discourage their use
  - added "DON'T USE THAT" note for them as well