### PR TITLE
Fix Service data type

### DIFF
--- a/builtin.aqua
+++ b/builtin.aqua
@@ -19,6 +19,7 @@ data Service:
     id: string
     blueprint_id: string
     owner_id: string
+    aliases: []string
 
 data FunctionSignature:
     arguments: []Argument


### PR DESCRIPTION
`Srv.list()` returns JSON like
```json
[
  {
    "aliases": [],
    "blueprint_id": "f9dd53fa8f2d80ecfc6c46ae530c1bf6db2e810aaa0b3f84ccdc807b43af84a3",
    "id": "7094f893-ec3c-4fdc-81e5-271daa60d392",
    "owner_id": "12D3KooWPmu9ejMpeqHT1oaQTUXPnE5byEVToQBnXTZBK6aHvHZ4"
  }
]
```
but the `Service` type doesn't reflect it.