### PR TITLE
fix: add workers.aqua to aqua-lib package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "builtin.aqua",
     "math.aqua",
-    "binary.aqua"
+    "binary.aqua",
+    "workers.aqua"
   ],
   "scripts": {
     "compile-dry": "aqua -i . --dry"


### PR DESCRIPTION
`workers.aqua` isn't available for importing (look [here](https://www.npmjs.com/package/@fluencelabs/aqua-lib/v/0.7.1?activeTab=code))
```
 import "@fluencelabs/aqua-lib/workers.aqua"
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
         File '@fluencelabs/aqua-lib/workers.aqua'
```

I _guess_, this PR should fix it