### PR TITLE
feat(workers)!: deprecate API w/o deal_id; add list [NET-565] (#61)

### DIFF
--- a/workers.aqua
+++ b/workers.aqua
@@ -1,41 +1,19 @@
 import PeerId from "./builtin.aqua"
 
 -- Available only on rust peers
-service DealWorker("worker"):
+service Worker("worker"):
     -- Creates new worker associated with `deal_id`.
     -- Throws an error if worker exists.
-    create(deal_id: ?string) -> PeerId
-
-    -- Returns worker peer id associated with `deal_id`.
-    -- Throws an error if worker doesn't exist.
-    get_peer_id(deal_id: ?string) -> PeerId
+    create(deal_id: string) -> PeerId
 
     -- Returns worker peer id associated with `deal_id`.
     -- Returns nil if worker doesn't exist.
-    get_worker_id(deal_id: ?string) -> ?PeerId
+    get_worker_id(deal_id: string) -> ?PeerId
 
     -- Removes worker with all deployed spells and services.
     -- Throws an error if worker doesn't exist.
     -- Worker can be removed only by worker creator or worker itself.
     remove(worker_id: PeerId)
 
--- Available only on rust peers
--- Suitable for direct hosting
-service Worker("worker"):
-    -- Creates new worker associated with `init_peer_id`.
-    -- Throws an error if worker exists.
-    create() -> PeerId
-
-    -- Returns worker peer id associated with `init_peer_id`.
-    -- Throws an error if worker doesn't exist.
-    -- WILL BE DEPRECATED SOON, use `get_worker_id` instead.
-    get_peer_id() -> PeerId
-
-    -- Returns worker peer id associated with `init_peer_id`.
-    -- Returns nil if worker doesn't exist.
-    get_worker_id() -> ?PeerId
-
-    -- Removes worker with all deployed spells and services.
-    -- Throws an error if worker doesn't exist.
-    -- Worker can be removed only by worker creator or worker itself.
-    remove(worker_id: PeerId)
+    -- Returns list of all workers.
+    list() -> []PeerId


### PR DESCRIPTION
BREAKING CHANGE: 
- deprecate the usage of Worker.get_peer_id that throws
- deprecate the usage of Worker API without deal_id (cli already generates deal_id even for workers deploy)
- add Worker.list
- rename DealWorker to Worker
