### PR TITLE
feat(builtins): update peer.identify

### DIFF
--- a/builtin.aqua
+++ b/builtin.aqua
@@ -35,12 +35,18 @@ data Interface:
     function_signatures: []FunctionSignature
     record_types: []RecordType
 
+data VmInfo:
+    ip: string
+    default_ssh_port: u16
+    forwarded_ports: []string
+
 data Info:
     external_addresses: []string
     node_version: string
     air_version: string
     spell_version: string
-    allowed_binaries: []string
+    allowed_effectors: []string
+    vm_info: ?VmInfo
 
 data ModuleWASIConfig:
     envs: ?Pairs


### PR DESCRIPTION
Add new fields to `Peer.identify` according to this [PR](https://github.com/fluencelabs/nox/pull/2364)

New output should look like this:
```
{
  "node_version": "0.27.1",
  "spell_version": "0.7.5",
  "air_version": "0.63.0",
  "vm_info": {
    "default_ssh_port": 922,
    "forwarded_ports": [
      "1000-65535"
    ],
    "ip": "1.1.1.1"
  },
  "external_addresses": [],
  "allowed_effectors": [
    "bafkreids22lgia5bqs63uigw4mqwhsoxvtnkpfqxqy5uwyyerrldsr32ce"
  ]
}